### PR TITLE
Enable android 21 compatibility

### DIFF
--- a/core/src/main/kotlin/se/gustavkarlsson/conveyor/internal/StoreImpl.kt
+++ b/core/src/main/kotlin/se/gustavkarlsson/conveyor/internal/StoreImpl.kt
@@ -1,9 +1,18 @@
 package se.gustavkarlsson.conveyor.internal
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
-import se.gustavkarlsson.conveyor.*
+import kotlinx.coroutines.launch
+import se.gustavkarlsson.conveyor.Action
+import se.gustavkarlsson.conveyor.StateAccess
+import se.gustavkarlsson.conveyor.Store
+import se.gustavkarlsson.conveyor.StoreCancelledException
+import se.gustavkarlsson.conveyor.StoreAlreadyStartedException
+import se.gustavkarlsson.conveyor.StoreNotYetStartedException
 
 @FlowPreview
 @ExperimentalCoroutinesApi


### PR DESCRIPTION
This PR gets rid of the `AtomicReference#getAndUpdate` call which was added in sdk version 24.