### PR TITLE
Improvements to state access

### DIFF
--- a/core/src/main/kotlin/se/gustavkarlsson/conveyor/StateAccess.kt
+++ b/core/src/main/kotlin/se/gustavkarlsson/conveyor/StateAccess.kt
@@ -6,5 +6,5 @@ public interface StateAccess<State> {
     public val flow: Flow<State>
     public fun get(): State
     public suspend fun set(state: State)
-    public suspend fun update(block: suspend (currentState: State) -> State): State
+    public suspend fun update(block: suspend State.() -> State): State
 }

--- a/core/src/test/kotlin/se/gustavkarlsson/conveyor/internal/LiveActionsManagerTest.kt
+++ b/core/src/test/kotlin/se/gustavkarlsson/conveyor/internal/LiveActionsManagerTest.kt
@@ -150,7 +150,7 @@ object LiveActionsManagerTest : Spek({
     describe("A LiveActionsManager with a delayed action that was incremented once") {
         val delayAction = action<Int> { access ->
             delay(1)
-            access.update { it + 1 }
+            access.update { this + 1 }
         }
         val subject by memoized { LiveActionsManager(listOf(delayAction)) }
         beforeEachTest { subject.increment() }
@@ -170,7 +170,7 @@ object LiveActionsManagerTest : Spek({
     describe("A LiveActionsManager with two delayed actions that was incremented once") {
         val delayAction = action<Int> { access ->
             delay(1)
-            access.update { it + 1 }
+            access.update { this + 1 }
         }
         val subject by memoized { LiveActionsManager(listOf(delayAction, delayAction)) }
         beforeEachTest { subject.increment() }

--- a/core/src/test/kotlin/se/gustavkarlsson/conveyor/internal/ManualActionsManagerTest.kt
+++ b/core/src/test/kotlin/se/gustavkarlsson/conveyor/internal/ManualActionsManagerTest.kt
@@ -45,7 +45,7 @@ object ManualActionsManagerTest : Spek({
             it("executes issued actions in parallel") {
                 val delayAction = action<Int> { access ->
                     delay(1)
-                    access.update { it + 1 }
+                    access.update { this + 1 }
                 }
                 subject.issue(delayAction)
                 subject.issue(delayAction)

--- a/core/src/test/kotlin/se/gustavkarlsson/conveyor/internal/StartActionFlowProviderTest.kt
+++ b/core/src/test/kotlin/se/gustavkarlsson/conveyor/internal/StartActionFlowProviderTest.kt
@@ -37,7 +37,7 @@ object StartActionFlowProviderTest : Spek({
     describe("A provider with a two delayed actions") {
         val delayAction = action<Int> { access ->
             delay(1)
-            access.update { it + 1 }
+            access.update { this + 1 }
         }
         val subject by memoized { StartActionProcessor(listOf(delayAction, delayAction)) }
 

--- a/core/src/test/kotlin/se/gustavkarlsson/conveyor/test/IncrementStateAction.kt
+++ b/core/src/test/kotlin/se/gustavkarlsson/conveyor/test/IncrementStateAction.kt
@@ -5,6 +5,6 @@ import se.gustavkarlsson.conveyor.StateAccess
 
 class IncrementStateAction(private val increment: Int = 1) : Action<Int> {
     override suspend fun execute(stateAccess: StateAccess<Int>) {
-        stateAccess.update { it + increment }
+        stateAccess.update { this + increment }
     }
 }

--- a/rx2/src/main/kotlin/se/gustavkarlsson/conveyor/rx2/RxStateAccess.kt
+++ b/rx2/src/main/kotlin/se/gustavkarlsson/conveyor/rx2/RxStateAccess.kt
@@ -8,5 +8,5 @@ public interface RxStateAccess<State : Any> {
     public val flowable: Flowable<State>
     public fun get(): State
     public fun set(state: State): Completable
-    public fun update(block: suspend (currentState: State) -> State): Single<State>
+    public fun update(block: Single<State>.() -> Single<State>): Single<State>
 }

--- a/rx2/src/main/kotlin/se/gustavkarlsson/conveyor/rx2/internal/RxStateAccessImpl.kt
+++ b/rx2/src/main/kotlin/se/gustavkarlsson/conveyor/rx2/internal/RxStateAccessImpl.kt
@@ -5,6 +5,7 @@ import io.reactivex.Flowable
 import io.reactivex.Single
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.rx2.asFlowable
+import kotlinx.coroutines.rx2.await
 import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.rx2.rxSingle
 import se.gustavkarlsson.conveyor.StateAccess
@@ -20,6 +21,10 @@ internal class RxStateAccessImpl<State : Any>(
 
     override fun set(state: State): Completable = rxCompletable { stateAccess.set(state) }
 
-    override fun update(block: suspend (currentState: State) -> State): Single<State> =
-        rxSingle { stateAccess.update(block) }
+    override fun update(block: Single<State>.() -> Single<State>): Single<State> =
+        rxSingle {
+            stateAccess.update {
+                Single.just(this).block().await()
+            }
+        }
 }

--- a/rx2/src/test/kotlin/se/gustavkarlsson/conveyor/rx2/internal/RxStateAccessImplTest.kt
+++ b/rx2/src/test/kotlin/se/gustavkarlsson/conveyor/rx2/internal/RxStateAccessImplTest.kt
@@ -23,11 +23,11 @@ object RxStateAccessImplTest : Spek({
             expectThat(result).isEqualTo(2)
         }
         it("update returns new state") {
-            val updateResult = subject.update { it + 1 }.blockingGet()
+            val updateResult = subject.update { map { it + 1 } }.blockingGet()
             expectThat(updateResult).isEqualTo(2)
         }
         it("update sets state") {
-            subject.update { it + 1 }.blockingGet()
+            subject.update { map { it + 1 } }.blockingGet()
             val result = subject.get()
             expectThat(result).isEqualTo(2)
         }


### PR DESCRIPTION
`StateAccess.updates` now has `State` as a receiver.
`RxStateAccess.update` now has `Single<State>` as receiver.